### PR TITLE
Add quotation marks to rc file in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The following example demonstrates how to embed an icon in a binary crate:
 ```rc
 // hello-world.rc
 
-1 ICON hello-world.ico
+1 ICON "hello-world.ico"
 ```
 
 ```rust


### PR DESCRIPTION
Hi, it seems, you forgot to put quotation marks around the icon file name in the example rc file in the Readme. I added them in the pull request.

This is my first pull request, so I hope everything is all right. I never worked with rc files before but its great that you made it so easy to be able to give an executable an icon. Thank you very much for your efforts.